### PR TITLE
add: new public route for curated calendar

### DIFF
--- a/src/controllers/CuratedEventController.ts
+++ b/src/controllers/CuratedEventController.ts
@@ -14,6 +14,13 @@ export class CuratedEventController extends ContentBaseController {
     });
   }
 
+  @httpGet("/public/calendar/:churchId/:curatedCalendarId")
+  public async getPublicForCuratedCalendar(@requestParam("churchId") churchId: string, @requestParam("curatedCalendarId") curatedCalendarId: string, req: express.Request<{}, {}, null>, res: express.Response): Promise<interfaces.IHttpActionResult> {
+    return this.actionWrapperAnon(req, res, async () => {
+      return await this.repositories.curatedEvent.loadForEvents(curatedCalendarId, churchId);
+    })
+  }
+
   @httpGet("/:id")
   public async get(@requestParam("id") id: string, req: express.Request<{}, {}, null>, res: express.Response): Promise<interfaces.IHttpActionResult> {
     return this.actionWrapper(req, res, async (au) => {

--- a/src/repositories/CuratedEventRepository.ts
+++ b/src/repositories/CuratedEventRepository.ts
@@ -58,7 +58,7 @@ export class CuratedEventRepository {
     + " WHEN ce.eventId IS NULL THEN e.groupId=ce.groupId"
     + " ELSE e.id=ce.eventId"
     + " END)"
-    + " where curatedCalendarId=? AND ce.churchId=?;";
+    + " where curatedCalendarId=? AND ce.churchId=? and e.visibility='public';";
     return DB.query(sql, [curatedCalendarId, churchId]);
   }
 


### PR DESCRIPTION
To be able to use Curated Calendar as a page-admin element, we would need a new public route that'll fetch all the events, so added that.

Fixed 'loadForEvents' query, cause we only want public events from groups.